### PR TITLE
Static Sequences and Publishers

### DIFF
--- a/Sources/NetworkReachability/API/NetworkMonitor+Combine.swift
+++ b/Sources/NetworkReachability/API/NetworkMonitor+Combine.swift
@@ -1,0 +1,141 @@
+// NetworkReachabiliy
+// NetworkMonitor+Combine.swift
+//
+// MIT License
+//
+// Copyright (c) 2021 Varun Santhanam
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the  Software), to deal
+//
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED  AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Combine
+import Foundation
+
+public extension NetworkMonitor {
+
+    /// A [`Publisher`](https://developer.apple.com/documentation/combine/publisher) of reachability updates
+    ///
+    /// Use this property to observe reachability updates with [Combine](https://developer.apple.com/documentation/combine).
+    ///
+    /// ```swift
+    /// let cancellable = NetworkMonitor.reachabilityPublisher
+    ///     .map(\.isReachable)
+    ///     .removeDuplicates()
+    ///     .replaceError(with: false)
+    ///     .sink { isReachable in
+    ///         // Do something with `isReachable`
+    ///     }
+    /// ```
+    static var reachabilityPublisher: NetworkMonitor.Publisher {
+        .init()
+    }
+
+    /// A [`Publisher`](https://developer.apple.com/documentation/combine/publisher) of reachability updates for a specific host
+    ///
+    /// Use this property to observe reachability updates with [Combine](https://developer.apple.com/documentation/combine).
+    ///
+    /// ```swift
+    /// let cancellable = NetworkMonitor.reachabilityPublisher(forHost: "apple.com")
+    ///     .map(\.isReachable)
+    ///     .removeDuplicates()
+    ///     .replaceError(with: false)
+    ///     .sink { isReachable in
+    ///         // Do something with `isReachable`
+    ///     }
+    /// ```
+    static func reachabilityPublisher(forHost host: String) -> NetworkMonitor.Publisher {
+        .init(host: host)
+    }
+
+    /// A [`Publisher`](https://developer.apple.com/documentation/combine/publisher) used to observe reachability updates for use with [Combine](https://developer.apple.com/documentation/combine).
+    ///
+    /// See ``reachabilityPublisher`` for usage.
+    struct Publisher: Combine.Publisher {
+
+        // MARK: - Publisher
+
+        public typealias Output = Reachability
+
+        public typealias Failure = Swift.Error
+
+        public func receive<S>(subscriber: S) where S: Subscriber, Failure == S.Failure, Reachability == S.Input {
+            let subscription = ReachabilitySubscription(subscriber: subscriber, host: host)
+            subscriber.receive(subscription: subscription)
+        }
+
+        // MARK: - Private
+
+        init(host: String? = nil) {
+            self.host = host
+        }
+
+        private var host: String?
+
+    }
+
+    private final class ReachabilitySubscription<S: Subscriber>: Subscription where S.Input == Reachability, S.Failure == Swift.Error {
+
+        // MARK: - Initializers
+
+        init(subscriber: S?, host: String?) {
+            self.subscriber = subscriber
+            self.host = host
+        }
+
+        // MARK: - Subscription
+
+        func request(_ demand: Subscribers.Demand) {
+            requested += 1
+            do {
+                let continuation: (NetworkMonitor.Result) -> Void = { [weak self] result in
+                    guard let self = self,
+                          let subscriber = self.subscriber,
+                          self.requested > .none else { return }
+                    self.requested -= .max(1)
+                    do {
+                        let reachability = try result.get()
+                        let newDemand = subscriber.receive(reachability)
+                        self.requested += newDemand
+                    } catch {
+                        subscriber.receive(completion: .failure(error))
+                    }
+                }
+                if let host = host {
+                    networkMonitor = try NetworkMonitor(host: host, continuation: continuation)
+                } else {
+                    networkMonitor = try NetworkMonitor(continuation: continuation)
+                }
+            } catch {
+                subscriber?.receive(completion: .failure(error))
+            }
+        }
+
+        func cancel() {
+            networkMonitor = nil
+        }
+
+        // MARK: - Private
+
+        private var subscriber: S?
+        private var networkMonitor: NetworkMonitor?
+        private var requested: Subscribers.Demand = .none
+        private var host: String?
+
+    }
+
+}

--- a/Sources/NetworkReachability/API/NetworkMonitor+Concurrency.swift
+++ b/Sources/NetworkReachability/API/NetworkMonitor+Concurrency.swift
@@ -1,0 +1,89 @@
+// NetworkReachabiliy
+// NetworkMonitor+Concurrency.swift
+//
+// MIT License
+//
+// Copyright (c) 2021 Varun Santhanam
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the  Software), to deal
+//
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED  AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+public extension NetworkMonitor {
+
+    /// An [`AsyncSequence`](https://developer.apple.com/documentation/swift/asyncsequence) of reachability updates
+    ///
+    /// Use [structured concurrency](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html) to iterate over reachability updates
+    ///
+    /// ```swift
+    /// do {
+    ///     for try await reachability in NetworkMonitor.reachability {
+    ///         // Do something with `reachability`
+    ///     }
+    /// } catch {
+    ///     // Handle error
+    /// }
+    /// ```
+    static var reachability: AsyncThrowingStream<Reachability, Swift.Error> {
+        .init(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            do {
+                _ = try NetworkMonitor() { result in
+                    do {
+                        let reachability = try result.get()
+                        continuation.yield(reachability)
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
+                }
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+    }
+
+    /// An [`AsyncSequence`](https://developer.apple.com/documentation/swift/asyncsequence) of reachability updates for a specific host
+    ///
+    /// Use [structured concurrency](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html) to iterate over reachability updates
+    ///
+    /// ```swift
+    /// do {
+    ///     for try await reachability in NetworkMonitor.reachability(forHost: "apple.com") {
+    ///         // Do something with `reachability`
+    ///     }
+    /// } catch {
+    ///     // Handle error
+    /// }
+    /// ```
+    static func reachability(forHost host: String) -> AsyncThrowingStream<Reachability, Swift.Error> {
+        .init(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            do {
+                _ = try NetworkMonitor(host: host) { result in
+                    do {
+                        let reachability = try result.get()
+                        continuation.yield(reachability)
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
+                }
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+    }
+}

--- a/Sources/NetworkReachability/API/NetworkMonitorDelegate.swift
+++ b/Sources/NetworkReachability/API/NetworkMonitorDelegate.swift
@@ -32,13 +32,11 @@ public protocol NetworkMonitorDelegate: AnyObject {
     /// - Parameters:
     ///   - monitor: The network monitor who's eachability changed
     ///   - reachability: The new reachability
-    @MainActor
     func networkMonitor(_ monitor: NetworkMonitor, didUpdateReachability reachability: Reachability)
 
     /// Sent to the delegate when the network monitor failed with an error
     /// - Parameters:
     ///   - monitor: The network monitor that failed
     ///   - error: The error that caused the monitor to fail
-    @MainActor
     func networkMonitor(_ monitor: NetworkMonitor, didFailWithError error: Error)
 }

--- a/Sources/NetworkReachability/API/Reachability.swift
+++ b/Sources/NetworkReachability/API/Reachability.swift
@@ -59,7 +59,7 @@ public enum Reachability: Equatable, Hashable, Sendable, CustomStringConvertible
     public var description: String {
         switch self {
         case .unknown:
-            return "Unknown Status"
+            return "Unknown Reachability Status"
         case .unavailable:
             return "Network Offline"
         case .wwan:

--- a/Sources/NetworkReachability/NetworkReachability.docc/NetworkReachability.md
+++ b/Sources/NetworkReachability/NetworkReachability.docc/NetworkReachability.md
@@ -13,7 +13,9 @@ NetworkReachability supports with the following Apple platform releases:
 
 ## Usage
 
-Basic usage of NetworkReachability is the same regardless of your observability mechanism. Initialize an instance of ``NetworkMonitor`` and retain it in memory. From there, you can observe changes using one of the mechanisms described below.
+To determine the current reachability status. Initialize an instance of ``NetworkMonitor`` and access `reachability` property. You can also pass in an optional delegate or update handler to recieve reachability status updates on the main thread. ``NetworkMonitor`` instances also fire notifications through `NotificationCenter.default`. See the examples these patterns and more below.
+
+## Examples
 
 ### Synchronously
 
@@ -25,7 +27,7 @@ final class MyObject {
     func checkReachability() {
         do {
             let monitor = try NetworkMonitor()
-            let reachability = try monitor.currentReachability
+            let reachability = try monitor.reachability
             switch reachability {
                 // do something
             }
@@ -58,7 +60,7 @@ final class MyObject {
         Task {
             do {
                 let monitor = try NetworkMonitor()
-                for try await reachability in monitor.reachability {
+                for try await reachability in NetworkMonitor.reachability {
                     switch reachability {
                         // do something
                     }
@@ -137,12 +139,10 @@ import NetworkReachability
 
 final class MyObject {
 
-    var monitor: NetworkMonitor?
     var cancellable: AnyCancellable?
     
     func startObserving() throws {
-        monitor = try NetworkMonitor()
-        cancellable = monitor?.reachabilityPublisher
+        cancellable = NetworkMonitor.reachabilityPublisher
             .sink { completion in
                     // handle completion
                 } receiveValue: { reachability in 
@@ -153,9 +153,8 @@ final class MyObject {
     }
     
     func stopObserving() {
-        cancellable?.stop()
+        cancellable?.cancel()
         cancellable = nil
-        monitor = nil
     }
 }
 ```
@@ -183,7 +182,7 @@ final class MyObject {
     func handleReachability(_ notification: Notification) {
         guard let monitor = notification.object as? NetworkMonitor else { return }
         do {
-            let reachability = try monitor.currentReachability
+            let reachability = try monitor.reachability
             switch reachability {
                 // do something
             }


### PR DESCRIPTION
- Refactor the async stream APIs to be static vars that do not require user initialization of a `NetworkMonitor`
- Refactor the combine APIs to use a custom publisher that does require user initialization of a `NetworkMonitor`
